### PR TITLE
Refactor iOS Wake-on-LAN to be more correct and less of a shotgun

### DIFF
--- a/Limelight/Network/WakeOnLanManager.h
+++ b/Limelight/Network/WakeOnLanManager.h
@@ -8,8 +8,17 @@
 
 #import "TemporaryHost.h"
 
+typedef enum {
+    WAKE_ERROR   = -1,
+    WAKE_SENT    = 0,
+    WAKE_SKIPPED = 1
+} WakeStatus;
+
+typedef WakeStatus (^WakeBlock)(struct ifaddrs *ifa);
+
 @interface WakeOnLanManager : NSObject
 
++ (void) getIPv4NetworkInterfacesWithVisitor:(WakeBlock)visitor;
 + (void) wakeHost:(TemporaryHost*)host;
 
 @end


### PR DESCRIPTION
This patch simplifies the WOL logic, and now loops through all active IPv4 interfaces and sends 1 magic packet to the broadcast address for each interface's subnet. Effectively this amounts to just one packet to the wifi interface's broadcast.

All the rest of the packets, to high UDP ports, unicast IPv4 and IPv6 addresses, 255.255.255.255, were not correct, even if they might sometimes wake a recently-awake PC that could still receive unicast packets by dumb luck.